### PR TITLE
Remove unused Prisma indexes

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -58,7 +58,6 @@ model Category {
   createdAt   DateTime  @default(now())
   updatedAt   DateTime  @updatedAt
 
-  @@index([slug])
 }
 
 // --- Module Sản phẩm ---
@@ -89,7 +88,6 @@ model Product {
   createdAt      DateTime      @default(now())
   updatedAt      DateTime      @updatedAt
 
-  @@index([slug])
   @@index([categoryId])
   @@index([name])
   @@fulltext([name, description])
@@ -167,7 +165,6 @@ model Order {
   updatedAt      DateTime      @updatedAt
 
   @@index([userId])
-  @@index([orderCode])
   @@index([status])
 }
 


### PR DESCRIPTION
## Summary
- clean up Prisma schema by removing unused index definitions

## Testing
- `npx prisma validate` *(fails: Failed to fetch sha256 checksum)*

------
https://chatgpt.com/codex/tasks/task_e_68406e079bf88321960f4326de7b3157