### PR TITLE
Implement user module API endpoints

### DIFF
--- a/src/app/api/admin/users/[userId]/route.ts
+++ b/src/app/api/admin/users/[userId]/route.ts
@@ -1,0 +1,65 @@
+import { NextRequest, NextResponse } from 'next/server'
+import prisma from '@/lib/prisma'
+import { authenticateToken, authorizeRole } from '@/lib/auth'
+import { adminUpdateUserSchema } from '@/lib/validators/user'
+
+export async function GET(req: NextRequest, { params }: { params: { userId: string } }) {
+  const payload = authenticateToken(req)
+  if (!payload) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  if (!authorizeRole(payload, 'ADMIN')) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id: params.userId },
+    select: {
+      id: true,
+      name: true,
+      email: true,
+      phone: true,
+      role: true,
+      addresses: {
+        select: {
+          id: true,
+          recipientName: true,
+          street: true,
+          city: true,
+          phone: true,
+          isDefault: true,
+        },
+      },
+    },
+  })
+
+  if (!user) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+
+  return NextResponse.json({ user })
+}
+
+export async function PUT(req: NextRequest, { params }: { params: { userId: string } }) {
+  const payload = authenticateToken(req)
+  if (!payload) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  if (!authorizeRole(payload, 'ADMIN')) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const data = await req.json()
+  const parsed = adminUpdateUserSchema.safeParse(data)
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten().fieldErrors }, { status: 400 })
+  }
+
+  const updated = await prisma.user.update({
+    where: { id: params.userId },
+    data: parsed.data,
+    select: { id: true, name: true, email: true, phone: true, role: true },
+  })
+
+  return NextResponse.json({ user: updated })
+}

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from 'next/server'
+import prisma from '@/lib/prisma'
+import { authenticateToken, authorizeRole } from '@/lib/auth'
+import { Role, Prisma } from '@prisma/client'
+
+export async function GET(req: NextRequest) {
+  const payload = authenticateToken(req)
+  if (!payload) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  if (!authorizeRole(payload, 'ADMIN')) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const { searchParams } = new URL(req.url)
+  const page = parseInt(searchParams.get('page') || '1', 10)
+  const limit = parseInt(searchParams.get('limit') || '10', 10)
+  const search = searchParams.get('search') || ''
+  const role = searchParams.get('role') as Role | null
+
+  const where: Prisma.UserWhereInput = {}
+  if (search) {
+    where.OR = [
+      { name: { contains: search, mode: 'insensitive' } },
+      { email: { contains: search, mode: 'insensitive' } },
+    ]
+  }
+  if (role) {
+    where.role = role
+  }
+
+  const [data, totalItems] = await Promise.all([
+    prisma.user.findMany({
+      where,
+      skip: (page - 1) * limit,
+      take: limit,
+      orderBy: { createdAt: 'desc' },
+      select: { id: true, name: true, email: true, phone: true, role: true },
+    }),
+    prisma.user.count({ where }),
+  ])
+
+  const totalPages = Math.ceil(totalItems / limit)
+  return NextResponse.json({ data, pagination: { page, limit, totalItems, totalPages } })
+}

--- a/src/app/api/users/me/addresses/[addressId]/default/route.ts
+++ b/src/app/api/users/me/addresses/[addressId]/default/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from 'next/server'
+import prisma from '@/lib/prisma'
+import { authenticateToken } from '@/lib/auth'
+
+export async function PATCH(req: NextRequest, { params }: { params: { addressId: string } }) {
+  const payload = authenticateToken(req)
+  if (!payload) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  // set all addresses isDefault false and set given address true
+  const address = await prisma.address.findFirst({ where: { id: params.addressId, userId: payload.userId } })
+  if (!address) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+
+  await prisma.address.updateMany({ where: { userId: payload.userId }, data: { isDefault: false } })
+  await prisma.address.update({ where: { id: params.addressId }, data: { isDefault: true } })
+
+  return NextResponse.json({})
+}

--- a/src/app/api/users/me/addresses/[addressId]/route.ts
+++ b/src/app/api/users/me/addresses/[addressId]/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from 'next/server'
+import prisma from '@/lib/prisma'
+import { authenticateToken } from '@/lib/auth'
+import { addressSchema } from '@/lib/validators/user'
+
+export async function PUT(req: NextRequest, { params }: { params: { addressId: string } }) {
+  const payload = authenticateToken(req)
+  if (!payload) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const data = await req.json()
+  const parsed = addressSchema.safeParse(data)
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten().fieldErrors }, { status: 400 })
+  }
+
+  const updated = await prisma.address.updateMany({
+    where: { id: params.addressId, userId: payload.userId },
+    data: parsed.data,
+  })
+  if (updated.count === 0) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+  const address = await prisma.address.findUnique({
+    where: { id: params.addressId },
+    select: { id: true, recipientName: true, street: true, city: true, phone: true, isDefault: true },
+  })
+
+  return NextResponse.json({ address })
+}
+
+export async function DELETE(req: NextRequest, { params }: { params: { addressId: string } }) {
+  const payload = authenticateToken(req)
+  if (!payload) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const deleted = await prisma.address.deleteMany({ where: { id: params.addressId, userId: payload.userId } })
+  if (deleted.count === 0) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+  return NextResponse.json({})
+}

--- a/src/app/api/users/me/addresses/route.ts
+++ b/src/app/api/users/me/addresses/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from 'next/server'
+import prisma from '@/lib/prisma'
+import { authenticateToken } from '@/lib/auth'
+import { addressSchema } from '@/lib/validators/user'
+
+export async function GET(req: NextRequest) {
+  const payload = authenticateToken(req)
+  if (!payload) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const addresses = await prisma.address.findMany({
+    where: { userId: payload.userId },
+    select: {
+      id: true,
+      recipientName: true,
+      street: true,
+      city: true,
+      phone: true,
+      isDefault: true,
+    },
+    orderBy: { createdAt: 'desc' },
+  })
+
+  return NextResponse.json({ addresses })
+}
+
+export async function POST(req: NextRequest) {
+  const payload = authenticateToken(req)
+  if (!payload) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const data = await req.json()
+  const parsed = addressSchema.safeParse(data)
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten().fieldErrors }, { status: 400 })
+  }
+
+  const address = await prisma.address.create({
+    data: { ...parsed.data, userId: payload.userId },
+    select: { id: true, recipientName: true, street: true, city: true, phone: true, isDefault: true },
+  })
+
+  return NextResponse.json({ address }, { status: 201 })
+}

--- a/src/app/api/users/me/route.ts
+++ b/src/app/api/users/me/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from 'next/server'
+import prisma from '@/lib/prisma'
+import { authenticateToken } from '@/lib/auth'
+import { updateProfileSchema } from '@/lib/validators/user'
+
+export async function GET(req: NextRequest) {
+  const payload = authenticateToken(req)
+  if (!payload) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { id: payload.userId },
+    select: {
+      id: true,
+      name: true,
+      email: true,
+      phone: true,
+      role: true,
+      addresses: {
+        where: { isDefault: true },
+        take: 1,
+        select: {
+          id: true,
+          recipientName: true,
+          street: true,
+          city: true,
+          phone: true,
+        },
+      },
+    },
+  })
+
+  if (!user) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+
+  const { addresses, ...rest } = user
+  const defaultAddress = addresses[0] || null
+  return NextResponse.json({ user: { ...rest, defaultAddress } })
+}
+
+export async function PUT(req: NextRequest) {
+  const payload = authenticateToken(req)
+  if (!payload) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const data = await req.json()
+  const parsed = updateProfileSchema.safeParse(data)
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten().fieldErrors }, { status: 400 })
+  }
+
+  const user = await prisma.user.update({
+    where: { id: payload.userId },
+    data: parsed.data,
+    select: { id: true, name: true, email: true, phone: true, role: true },
+  })
+
+  return NextResponse.json({ user })
+}

--- a/src/lib/validators/user.ts
+++ b/src/lib/validators/user.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod'
+
+export const updateProfileSchema = z.object({
+  name: z.string().min(1).optional(),
+  phone: z.string().min(1).optional(),
+})
+export type UpdateProfileInput = z.infer<typeof updateProfileSchema>
+
+export const addressSchema = z.object({
+  recipientName: z.string().min(1),
+  street: z.string().min(1),
+  city: z.string().min(1),
+  phone: z.string().min(1),
+})
+export type AddressInput = z.infer<typeof addressSchema>
+
+export const adminUpdateUserSchema = updateProfileSchema.extend({
+  role: z.enum(['CUSTOMER', 'ADMIN']).optional(),
+})
+export type AdminUpdateUserInput = z.infer<typeof adminUpdateUserSchema>


### PR DESCRIPTION
## Summary
- add user validation schemas
- implement `/api/users/me` to get and update profile
- add CRUD routes for user addresses
- add admin routes to list and manage users

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_684079cca6808321aa32610c287b6806