### PR TITLE
Implement Category module API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "next": "15.3.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "slugify": "^1.6.6",
         "zod": "^3.22.4"
       },
       "devDependencies": {
@@ -5763,6 +5764,15 @@
       "optional": true,
       "dependencies": {
         "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/slugify": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
+      "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/source-map-js": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "next": "15.3.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "slugify": "^1.6.6",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/src/app/api/admin/categories/[categoryId]/route.ts
+++ b/src/app/api/admin/categories/[categoryId]/route.ts
@@ -1,0 +1,78 @@
+import { NextRequest, NextResponse } from 'next/server'
+import prisma from '@/lib/prisma'
+import { authenticateToken, authorizeRole } from '@/lib/auth'
+import { updateCategorySchema } from '@/lib/validators/category'
+import slugify from 'slugify'
+import { Prisma } from '@prisma/client'
+
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: { categoryId: string } }
+) {
+  const payload = authenticateToken(req)
+  if (!payload) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  if (!authorizeRole(payload, 'ADMIN')) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const data = await req.json()
+  const parsed = updateCategorySchema.safeParse(data)
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten().fieldErrors }, { status: 400 })
+  }
+
+  const updateData: Prisma.CategoryUpdateInput = { ...parsed.data }
+  if (parsed.data.name && !parsed.data.slug) {
+    updateData.slug = slugify(parsed.data.name, { lower: true, strict: true })
+  } else if (parsed.data.slug) {
+    updateData.slug = slugify(parsed.data.slug, { lower: true, strict: true })
+  }
+
+  if (updateData.slug || updateData.name) {
+    const orConditions: Prisma.CategoryWhereInput[] = []
+    if (updateData.slug) orConditions.push({ slug: updateData.slug as string })
+    if (updateData.name) orConditions.push({ name: updateData.name as string })
+    const exist = await prisma.category.findFirst({
+      where: {
+        OR: orConditions,
+        NOT: { id: params.categoryId },
+      },
+    })
+    if (exist) {
+      return NextResponse.json({ error: 'Category already exists' }, { status: 409 })
+    }
+  }
+
+  const category = await prisma.category.update({
+    where: { id: params.categoryId },
+    data: { ...updateData, parentId: parsed.data.parentId ?? undefined },
+  })
+  return NextResponse.json({ category })
+}
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: { categoryId: string } }
+) {
+  const payload = authenticateToken(req)
+  if (!payload) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  if (!authorizeRole(payload, 'ADMIN')) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const childCount = await prisma.category.count({ where: { parentId: params.categoryId } })
+  if (childCount > 0) {
+    return NextResponse.json({ error: 'Category has subcategories' }, { status: 400 })
+  }
+  const productCount = await prisma.product.count({ where: { categoryId: params.categoryId } })
+  if (productCount > 0) {
+    return NextResponse.json({ error: 'Category has products' }, { status: 400 })
+  }
+
+  await prisma.category.delete({ where: { id: params.categoryId } })
+  return NextResponse.json({}, { status: 204 })
+}

--- a/src/app/api/admin/categories/route.ts
+++ b/src/app/api/admin/categories/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from 'next/server'
+import prisma from '@/lib/prisma'
+import { authenticateToken, authorizeRole } from '@/lib/auth'
+import { createCategorySchema } from '@/lib/validators/category'
+import slugify from 'slugify'
+
+export async function POST(req: NextRequest) {
+  const payload = authenticateToken(req)
+  if (!payload) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  if (!authorizeRole(payload, 'ADMIN')) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const data = await req.json()
+  const parsed = createCategorySchema.safeParse(data)
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten().fieldErrors }, { status: 400 })
+  }
+
+  const slug = slugify(parsed.data.name, { lower: true, strict: true })
+  const exists = await prisma.category.findFirst({ where: { OR: [ { name: parsed.data.name }, { slug } ] } })
+  if (exists) {
+    return NextResponse.json({ error: 'Category already exists' }, { status: 409 })
+  }
+
+  const category = await prisma.category.create({
+    data: {
+      ...parsed.data,
+      slug,
+      parentId: parsed.data.parentId || null,
+    },
+  })
+  return NextResponse.json({ category }, { status: 201 })
+}

--- a/src/app/api/categories/[slugOrId]/route.ts
+++ b/src/app/api/categories/[slugOrId]/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server'
+import prisma from '@/lib/prisma'
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { slugOrId: string } }
+) {
+  const category = await prisma.category.findFirst({
+    where: {
+      OR: [{ slug: params.slugOrId }, { id: params.slugOrId }],
+    },
+    include: { _count: { select: { products: true } } },
+  })
+  if (!category) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+  return NextResponse.json({ category })
+}

--- a/src/app/api/categories/route.ts
+++ b/src/app/api/categories/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest, NextResponse } from 'next/server'
+import prisma from '@/lib/prisma'
+import { Category } from '@prisma/client'
+
+interface CategoryNode extends Category {
+  children: CategoryNode[]
+  _count: { products: number }
+}
+
+function buildTree(categories: CategoryNode[]) {
+  const map = new Map<string, CategoryNode>()
+  const roots: CategoryNode[] = []
+  for (const cat of categories) {
+    cat.children = []
+    map.set(cat.id, cat)
+  }
+  for (const cat of categories) {
+    if (cat.parentId) {
+      const parent = map.get(cat.parentId)
+      if (parent) parent.children.push(cat)
+    } else {
+      roots.push(cat)
+    }
+  }
+  return roots
+}
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url)
+  const parentId = searchParams.get('parentId')
+  const tree = searchParams.get('tree') === 'true'
+
+  if (tree) {
+    const categories = (await prisma.category.findMany({
+      orderBy: { createdAt: 'asc' },
+      include: { _count: { select: { products: true } } },
+    })) as CategoryNode[]
+    const data = buildTree(categories)
+    return NextResponse.json({ categories: data })
+  }
+
+  const categories = (await prisma.category.findMany({
+    where: { parentId: parentId || null },
+    orderBy: { createdAt: 'asc' },
+    include: { _count: { select: { products: true } } },
+  })) as CategoryNode[]
+
+  return NextResponse.json({ categories })
+}

--- a/src/lib/validators/category.ts
+++ b/src/lib/validators/category.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod'
+
+export const createCategorySchema = z.object({
+  name: z.string().min(1),
+  description: z.string().optional(),
+  parentId: z.string().optional(),
+  imageUrl: z.string().url().optional(),
+})
+export type CreateCategoryInput = z.infer<typeof createCategorySchema>
+
+export const updateCategorySchema = createCategorySchema.partial().extend({
+  slug: z.string().min(1).optional(),
+})
+export type UpdateCategoryInput = z.infer<typeof updateCategorySchema>


### PR DESCRIPTION
## Summary
- add category validators
- implement public category listing and detail routes
- add admin create, update, delete category routes
- install slugify for slug generation

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68407d2dd7ec832194e0bc9dd4aaae3d