### PR TITLE
Implement cart module API

### DIFF
--- a/src/app/api/cart/items/[cartItemId]/route.ts
+++ b/src/app/api/cart/items/[cartItemId]/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from 'next/server'
+import prisma from '@/lib/prisma'
+import { authenticateToken } from '@/lib/auth'
+import { updateCartItemSchema } from '@/lib/validators/cart'
+import { fetchCart } from '../../route'
+
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: { cartItemId: string } },
+) {
+  const payload = authenticateToken(req)
+  if (!payload) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const data = await req.json()
+  const parsed = updateCartItemSchema.safeParse(data)
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten().fieldErrors }, { status: 400 })
+  }
+
+  const item = await prisma.cartItem.findFirst({
+    where: { id: params.cartItemId, cart: { userId: payload.userId } },
+    include: { product: { select: { stockQuantity: true } } },
+  })
+  if (!item) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+
+  if (parsed.data.quantity === 0) {
+    await prisma.cartItem.delete({ where: { id: item.id } })
+  } else {
+    if (parsed.data.quantity > item.product.stockQuantity) {
+      return NextResponse.json({ error: 'Exceeds stock' }, { status: 400 })
+    }
+    await prisma.cartItem.update({ where: { id: item.id }, data: { quantity: parsed.data.quantity } })
+  }
+
+  const updated = await fetchCart(payload.userId)
+  return NextResponse.json(updated)
+}
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: { cartItemId: string } },
+) {
+  const payload = authenticateToken(req)
+  if (!payload) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const deleted = await prisma.cartItem.deleteMany({
+    where: { id: params.cartItemId, cart: { userId: payload.userId } },
+  })
+  if (deleted.count === 0) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+
+  const updated = await fetchCart(payload.userId)
+  return NextResponse.json(updated)
+}

--- a/src/app/api/cart/items/route.ts
+++ b/src/app/api/cart/items/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from 'next/server'
+import prisma from '@/lib/prisma'
+import { authenticateToken } from '@/lib/auth'
+import { addCartItemSchema } from '@/lib/validators/cart'
+import { fetchCart } from '../route'
+
+export async function POST(req: NextRequest) {
+  const payload = authenticateToken(req)
+  if (!payload) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const data = await req.json()
+  const parsed = addCartItemSchema.safeParse(data)
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten().fieldErrors }, { status: 400 })
+  }
+
+  const { productId, quantity, size, color } = parsed.data
+  const product = await prisma.product.findFirst({
+    where: { id: productId, NOT: { status: 'UNLISTED' } },
+    select: { price: true, promotionalPrice: true, stockQuantity: true }
+  })
+  if (!product) {
+    return NextResponse.json({ error: 'Product not found' }, { status: 404 })
+  }
+  if (quantity > product.stockQuantity) {
+    return NextResponse.json({ error: 'Out of stock' }, { status: 400 })
+  }
+
+  const cart = await prisma.cart.upsert({
+    where: { userId: payload.userId },
+    update: {},
+    create: { userId: payload.userId }
+  })
+
+  const existing = await prisma.cartItem.findFirst({
+    where: { cartId: cart.id, productId, size: size || null, color: color || null }
+  })
+
+  if (existing) {
+    const newQty = existing.quantity + quantity
+    if (newQty > product.stockQuantity) {
+      return NextResponse.json({ error: 'Exceeds stock' }, { status: 400 })
+    }
+    await prisma.cartItem.update({ where: { id: existing.id }, data: { quantity: newQty } })
+  } else {
+    await prisma.cartItem.create({
+      data: {
+        cartId: cart.id,
+        productId,
+        quantity,
+        size,
+        color,
+        price: product.promotionalPrice ?? product.price,
+      }
+    })
+  }
+
+  const updated = await fetchCart(payload.userId)
+  return NextResponse.json(updated)
+}

--- a/src/app/api/cart/route.ts
+++ b/src/app/api/cart/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from 'next/server'
+import prisma from '@/lib/prisma'
+import { authenticateToken } from '@/lib/auth'
+
+export async function fetchCart(userId: string) {
+  let cart = await prisma.cart.findUnique({
+    where: { userId },
+    include: {
+      items: {
+        include: {
+          product: {
+            select: {
+              id: true,
+              name: true,
+              slug: true,
+              images: { where: { isDefault: true }, take: 1, select: { url: true } },
+              price: true,
+              promotionalPrice: true,
+              stockQuantity: true,
+              status: true,
+            },
+          },
+        },
+        orderBy: { createdAt: 'asc' },
+      },
+    },
+  })
+
+  if (!cart) {
+    cart = await prisma.cart.create({ data: { userId } })
+    return { ...cart, items: [], totalAmount: 0 }
+  }
+
+  const validItems = [] as typeof cart.items
+  for (const item of cart.items) {
+    if (!item.product || item.product.status === 'UNLISTED' || item.product.stockQuantity <= 0) {
+      await prisma.cartItem.delete({ where: { id: item.id } })
+      continue
+    }
+    validItems.push(item)
+  }
+  const totalAmount = validItems.reduce((sum, item) => sum + item.quantity * item.price, 0)
+  return { ...cart, items: validItems, totalAmount }
+}
+
+export async function GET(req: NextRequest) {
+  const payload = authenticateToken(req)
+  if (!payload) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const data = await fetchCart(payload.userId)
+  return NextResponse.json(data)
+}

--- a/src/lib/validators/cart.ts
+++ b/src/lib/validators/cart.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod'
+
+export const addCartItemSchema = z.object({
+  productId: z.string().min(1),
+  quantity: z.number().int().positive(),
+  size: z.string().min(1).optional(),
+  color: z.string().min(1).optional(),
+})
+export type AddCartItemInput = z.infer<typeof addCartItemSchema>
+
+export const updateCartItemSchema = z.object({
+  quantity: z.number().int().nonnegative(),
+})
+export type UpdateCartItemInput = z.infer<typeof updateCartItemSchema>


### PR DESCRIPTION
## Summary
- implement new cart API endpoints for shopping cart management
- add cart validators for adding and updating items

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6840852c8a1c832187c88f4bbc570f42