### PR TITLE
Implement order API module and cart fix

### DIFF
--- a/src/app/api/admin/orders/[orderId]/status/route.ts
+++ b/src/app/api/admin/orders/[orderId]/status/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from 'next/server'
+import prisma from '@/lib/prisma'
+import { authenticateToken, authorizeRole } from '@/lib/auth'
+import { updateOrderStatusSchema } from '@/lib/validators/order'
+import { OrderStatus } from '@prisma/client'
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: { orderId: string } },
+) {
+  const payload = authenticateToken(req)
+  if (!payload) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  if (!authorizeRole(payload, 'ADMIN')) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const data = await req.json()
+  const parsed = updateOrderStatusSchema.safeParse(data)
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten().fieldErrors }, { status: 400 })
+  }
+
+  const order = await prisma.order.findUnique({
+    where: { id: params.orderId },
+    include: { items: true },
+  })
+  if (!order) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+
+  const newStatus = parsed.data.status as OrderStatus
+
+  try {
+    const result = await prisma.$transaction(async (tx) => {
+      const updated = await tx.order.update({
+        where: { id: order.id },
+        data: { status: newStatus },
+      })
+
+      await tx.orderStatusUpdate.create({
+        data: { orderId: order.id, status: newStatus, updatedBy: payload.userId },
+      })
+
+      if (newStatus === 'CANCELLED') {
+        for (const item of order.items) {
+          await tx.product.update({
+            where: { id: item.productId },
+            data: { stockQuantity: { increment: item.quantity } },
+          })
+        }
+      }
+
+      return updated
+    })
+
+    return NextResponse.json({ order: result })
+  } catch {
+    return NextResponse.json({ error: 'Update failed' }, { status: 400 })
+  }
+}

--- a/src/app/api/admin/orders/route.ts
+++ b/src/app/api/admin/orders/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from 'next/server'
+import prisma from '@/lib/prisma'
+import { authenticateToken, authorizeRole } from '@/lib/auth'
+import { OrderStatus, Prisma } from '@prisma/client'
+
+export async function GET(req: NextRequest) {
+  const payload = authenticateToken(req)
+  if (!payload) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  if (!authorizeRole(payload, 'ADMIN')) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  const { searchParams } = new URL(req.url)
+  const page = parseInt(searchParams.get('page') || '1', 10)
+  const limit = parseInt(searchParams.get('limit') || '10', 10)
+  const status = searchParams.get('status') as OrderStatus | null
+  const search = searchParams.get('search') || ''
+
+  const where: Prisma.OrderWhereInput = {}
+  if (status) where.status = status
+  if (search) {
+    where.OR = [
+      { orderCode: { contains: search, mode: 'insensitive' } },
+      { user: { name: { contains: search, mode: 'insensitive' } } },
+      { user: { email: { contains: search, mode: 'insensitive' } } },
+    ]
+  }
+
+  const [data, totalItems] = await Promise.all([
+    prisma.order.findMany({
+      where,
+      skip: (page - 1) * limit,
+      take: limit,
+      orderBy: { createdAt: 'desc' },
+      include: { user: { select: { id: true, name: true, email: true } } },
+    }),
+    prisma.order.count({ where }),
+  ])
+
+  const totalPages = Math.ceil(totalItems / limit)
+  return NextResponse.json({ data, pagination: { page, limit, totalItems, totalPages } })
+}

--- a/src/app/api/cart/route.ts
+++ b/src/app/api/cart/route.ts
@@ -27,7 +27,10 @@ export async function fetchCart(userId: string) {
   })
 
   if (!cart) {
-    cart = await prisma.cart.create({ data: { userId } })
+    cart = await prisma.cart.create({
+      data: { userId },
+      include: { items: true },
+    })
     return { ...cart, items: [], totalAmount: 0 }
   }
 

--- a/src/app/api/orders/[orderIdOrCode]/route.ts
+++ b/src/app/api/orders/[orderIdOrCode]/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from 'next/server'
+import prisma from '@/lib/prisma'
+import { authenticateToken } from '@/lib/auth'
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { orderIdOrCode: string } },
+) {
+  const payload = authenticateToken(req)
+  if (!payload) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const order = await prisma.order.findFirst({
+    where: {
+      OR: [{ id: params.orderIdOrCode }, { orderCode: params.orderIdOrCode }],
+    },
+    include: {
+      items: true,
+      statusHistory: true,
+    },
+  })
+
+  if (!order) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+
+  if (payload.role !== 'ADMIN' && order.userId !== payload.userId) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  }
+
+  return NextResponse.json({ order })
+}

--- a/src/app/api/orders/my/route.ts
+++ b/src/app/api/orders/my/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from 'next/server'
+import prisma from '@/lib/prisma'
+import { authenticateToken } from '@/lib/auth'
+import { OrderStatus, Prisma } from '@prisma/client'
+
+export async function GET(req: NextRequest) {
+  const payload = authenticateToken(req)
+  if (!payload) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const { searchParams } = new URL(req.url)
+  const page = parseInt(searchParams.get('page') || '1', 10)
+  const limit = parseInt(searchParams.get('limit') || '10', 10)
+  const status = searchParams.get('status') as OrderStatus | null
+
+  const where: Prisma.OrderWhereInput = { userId: payload.userId }
+  if (status) where.status = status
+
+  const [data, totalItems] = await Promise.all([
+    prisma.order.findMany({
+      where,
+      skip: (page - 1) * limit,
+      take: limit,
+      orderBy: { createdAt: 'desc' },
+      select: { id: true, orderCode: true, createdAt: true, totalAmount: true, status: true },
+    }),
+    prisma.order.count({ where }),
+  ])
+
+  const totalPages = Math.ceil(totalItems / limit)
+  return NextResponse.json({ data, pagination: { page, limit, totalItems, totalPages } })
+}

--- a/src/app/api/orders/route.ts
+++ b/src/app/api/orders/route.ts
@@ -1,0 +1,120 @@
+import { NextRequest, NextResponse } from 'next/server'
+import prisma from '@/lib/prisma'
+import { authenticateToken } from '@/lib/auth'
+import { createOrderSchema } from '@/lib/validators/order'
+import { Prisma } from '@prisma/client'
+
+export async function POST(req: NextRequest) {
+  const payload = authenticateToken(req)
+  if (!payload) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  const data = await req.json()
+  const parsed = createOrderSchema.safeParse(data)
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten().fieldErrors }, { status: 400 })
+  }
+
+  const { shippingAddressId, shippingAddress, paymentMethod, notes } = parsed.data
+
+  const cart = await prisma.cart.findUnique({
+    where: { userId: payload.userId },
+    include: {
+      items: {
+        include: {
+          product: {
+            include: { images: { where: { isDefault: true }, take: 1 } },
+          },
+        },
+      },
+    },
+  })
+
+  if (!cart || cart.items.length === 0) {
+    return NextResponse.json({ error: 'Cart is empty' }, { status: 400 })
+  }
+
+  let address
+  if (shippingAddressId) {
+    address = await prisma.address.findFirst({
+      where: { id: shippingAddressId, userId: payload.userId },
+    })
+    if (!address) {
+      return NextResponse.json({ error: 'Invalid address' }, { status: 400 })
+    }
+  } else if (shippingAddress) {
+    address = shippingAddress
+  }
+
+  try {
+    const result = await prisma.$transaction(async (tx) => {
+      for (const item of cart.items) {
+        if (!item.product || item.quantity > item.product.stockQuantity) {
+          throw new Error('Out of stock')
+        }
+      }
+
+      const order = await tx.order.create({
+        data: {
+          userId: payload.userId,
+          shippingAddress: {
+            recipientName: address.recipientName,
+            street: address.street,
+            city: address.city,
+            phone: address.phone,
+          },
+          paymentMethod,
+          notes,
+          totalAmount: 0,
+        },
+      })
+
+      let total = 0
+      for (const item of cart.items) {
+        await tx.orderItem.create({
+          data: {
+            orderId: order.id,
+            productId: item.productId,
+            quantity: item.quantity,
+            price: item.price,
+            size: item.size,
+            color: item.color,
+            productSnapshot: {
+              name: item.product.name,
+              image: item.product.images[0]?.url || '',
+            } as Prisma.InputJsonValue,
+          },
+        })
+        await tx.product.update({
+          where: { id: item.productId },
+          data: { stockQuantity: { decrement: item.quantity } },
+        })
+        total += item.price * item.quantity
+      }
+
+      await tx.order.update({
+        where: { id: order.id },
+        data: { totalAmount: total },
+      })
+
+      await tx.orderStatusUpdate.create({
+        data: { orderId: order.id, status: 'PENDING' },
+      })
+
+      await tx.cartItem.deleteMany({ where: { cartId: cart.id } })
+      await tx.cart.delete({ where: { id: cart.id } })
+
+      return {
+        orderId: order.id,
+        orderCode: order.orderCode,
+        status: order.status,
+        totalAmount: total,
+      }
+    })
+
+    return NextResponse.json(result, { status: 201 })
+  } catch {
+    return NextResponse.json({ error: 'Failed to create order' }, { status: 400 })
+  }
+}

--- a/src/lib/validators/order.ts
+++ b/src/lib/validators/order.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod'
+import { addressSchema } from './user'
+
+export const createOrderSchema = z.object({
+  shippingAddressId: z.string().min(1).optional(),
+  shippingAddress: addressSchema.optional(),
+  paymentMethod: z.enum(['COD']).default('COD'),
+  notes: z.string().optional(),
+}).refine(data => data.shippingAddressId || data.shippingAddress, {
+  message: 'Shipping address required',
+  path: ['shippingAddressId'],
+})
+export type CreateOrderInput = z.infer<typeof createOrderSchema>
+
+export const updateOrderStatusSchema = z.object({
+  status: z.enum(['PROCESSING', 'SHIPPING', 'DELIVERED', 'CANCELLED']),
+})
+export type UpdateOrderStatusInput = z.infer<typeof updateOrderStatusSchema>


### PR DESCRIPTION
## Summary
- fix cart creation to return items
- add order validators
- implement order API endpoints for creating and listing orders
- add admin order listing and status update endpoints

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6840873fd29c83218bd3eff2c1bd98d8