### PR TITLE
Add authentication frontend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,14 @@
       "name": "maisonbyk",
       "version": "0.1.0",
       "dependencies": {
+        "@hookform/resolvers": "^5.0.1",
         "bcryptjs": "^2.4.3",
         "clsx": "^2.1.1",
         "jsonwebtoken": "^9.0.2",
         "next": "15.3.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-hook-form": "^7.57.0",
         "slugify": "^1.6.6",
         "tailwind-merge": "^3.3.0",
         "zod": "^3.22.4",
@@ -234,6 +236,18 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.0.1.tgz",
+      "integrity": "sha512-u/+Jp83luQNx9AdyW2fIPGY6Y7NG68eN2ZW8FOJYL+M0i4s49+refdJdOp/A9n9HFQtQs3HIDHQvX3ZET2o7YA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -1066,6 +1080,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
@@ -1428,7 +1448,7 @@
       "version": "19.1.6",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.6.tgz",
       "integrity": "sha512-JeG0rEWak0N6Itr6QUx+X60uQmN+5t3j9r/OVDtWzFXKaj6kD1BwJzOksD0FF6iWxZlbE1kB0q9vtnU2ekqa1Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -2505,7 +2525,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -5356,6 +5376,22 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.57.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.57.0.tgz",
+      "integrity": "sha512-RbEks3+cbvTP84l/VXGUZ+JMrKOS8ykQCRYdm5aYsxnDquL0vspsyNhGRO7pcH6hsZqWlPOjLye7rJqdtdAmlg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -9,12 +9,14 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.0.1",
     "bcryptjs": "^2.4.3",
     "clsx": "^2.1.1",
     "jsonwebtoken": "^9.0.2",
     "next": "15.3.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-hook-form": "^7.57.0",
     "slugify": "^1.6.6",
     "tailwind-merge": "^3.3.0",
     "zod": "^3.22.4",

--- a/src/app/(admin)/layout.tsx
+++ b/src/app/(admin)/layout.tsx
@@ -1,3 +1,24 @@
+'use client'
+
+import { useAuth } from '@/hooks/useAuth'
+import { useEffect } from 'react'
+import { useRouter, usePathname } from 'next/navigation'
+
 export default function AdminLayout({ children }: { children: React.ReactNode }) {
+  const { isAuthenticated, user } = useAuth()
+  const router = useRouter()
+  const pathname = usePathname()
+
+  useEffect(() => {
+    if (pathname === '/admin/login') return
+    if (!isAuthenticated || user?.role !== 'ADMIN') {
+      router.push('/admin/login')
+    }
+  }, [isAuthenticated, user, pathname, router])
+
+  if (!isAuthenticated && pathname !== '/admin/login') {
+    return null
+  }
+
   return <div>{children}</div>
 }

--- a/src/app/(customer)/login/page.tsx
+++ b/src/app/(customer)/login/page.tsx
@@ -5,19 +5,19 @@ import { useRouter } from 'next/navigation'
 import { useEffect } from 'react'
 import LoginForm from '@/components/features/auth/LoginForm'
 
-export default function AdminLogin() {
-  const { isAuthenticated, user } = useAuth()
+export default function CustomerLoginPage() {
+  const { isAuthenticated } = useAuth()
   const router = useRouter()
 
   useEffect(() => {
-    if (isAuthenticated && user?.role === 'ADMIN') {
-      router.push('/admin/dashboard')
+    if (isAuthenticated) {
+      router.push('/')
     }
-  }, [isAuthenticated, user, router])
+  }, [isAuthenticated, router])
 
   return (
     <div className="max-w-sm mx-auto py-10">
-      <LoginForm isAdminLogin />
+      <LoginForm />
     </div>
   )
 }

--- a/src/app/(customer)/register/page.tsx
+++ b/src/app/(customer)/register/page.tsx
@@ -1,0 +1,23 @@
+'use client'
+
+import { useAuth } from '@/hooks/useAuth'
+import { useRouter } from 'next/navigation'
+import { useEffect } from 'react'
+import RegisterForm from '@/components/features/auth/RegisterForm'
+
+export default function RegisterPage() {
+  const { isAuthenticated } = useAuth()
+  const router = useRouter()
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      router.push('/')
+    }
+  }, [isAuthenticated, router])
+
+  return (
+    <div className="max-w-sm mx-auto py-10">
+      <RegisterForm />
+    </div>
+  )
+}

--- a/src/components/features/auth/LoginForm.tsx
+++ b/src/components/features/auth/LoginForm.tsx
@@ -1,0 +1,61 @@
+'use client'
+
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { loginSchema, type LoginInput } from '@/lib/validators/auth'
+import { Button } from '@/components/ui/Button'
+import { Input } from '@/components/ui/Input'
+import { useAuth } from '@/hooks/useAuth'
+import { useRouter } from 'next/navigation'
+import Link from 'next/link'
+
+interface LoginFormProps {
+  isAdminLogin?: boolean
+}
+
+export default function LoginForm({ isAdminLogin = false }: LoginFormProps) {
+  const { login } = useAuth()
+  const router = useRouter()
+  const [error, setError] = useState<string | null>(null)
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<LoginInput>({ resolver: zodResolver(loginSchema) })
+
+  const onSubmit = async (data: LoginInput) => {
+    setError(null)
+    try {
+      await login(data)
+      router.push(isAdminLogin ? '/admin/dashboard' : '/')
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Login failed'
+      setError(message)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+      <Input type="email" placeholder="Email" {...register('email')} />
+      {errors.email && (
+        <div className="text-red-500 text-sm">{errors.email.message}</div>
+      )}
+      <Input type="password" placeholder="Password" {...register('password')} />
+      {errors.password && (
+        <div className="text-red-500 text-sm">{errors.password.message}</div>
+      )}
+      {error && <div className="text-red-500 text-sm">{error}</div>}
+      <Button type="submit" className="w-full" disabled={isSubmitting}>
+        Đăng nhập
+      </Button>
+      {!isAdminLogin && (
+        <div className="text-center text-sm">
+          <Link href="/register" className="text-sky-600 hover:underline">
+            Đăng ký
+          </Link>
+        </div>
+      )}
+    </form>
+  )
+}

--- a/src/components/features/auth/RegisterForm.tsx
+++ b/src/components/features/auth/RegisterForm.tsx
@@ -1,0 +1,80 @@
+'use client'
+
+import { useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { z } from 'zod'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { registerSchema, type RegisterInput } from '@/lib/validators/auth'
+import { Button } from '@/components/ui/Button'
+import { Input } from '@/components/ui/Input'
+import { useAuth } from '@/hooks/useAuth'
+import { useRouter } from 'next/navigation'
+import Link from 'next/link'
+
+const formSchema = registerSchema.extend({
+  confirmPassword: z.string(),
+}).refine((data) => data.password === data.confirmPassword, {
+  message: 'Passwords do not match',
+  path: ['confirmPassword'],
+})
+
+type FormData = z.infer<typeof formSchema>
+
+export default function RegisterForm() {
+  const { register: registerUser } = useAuth()
+  const router = useRouter()
+  const [error, setError] = useState<string | null>(null)
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<FormData>({ resolver: zodResolver(formSchema) })
+
+  const onSubmit = async (data: FormData) => {
+    setError(null)
+    const { confirmPassword: _confirm, ...payload } = data
+    void _confirm
+    try {
+      await registerUser(payload as RegisterInput)
+      router.push('/')
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Register failed'
+      setError(message)
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+      <Input placeholder="Họ tên" {...register('name')} />
+      {errors.name && (
+        <div className="text-red-500 text-sm">{errors.name.message}</div>
+      )}
+      <Input type="email" placeholder="Email" {...register('email')} />
+      {errors.email && (
+        <div className="text-red-500 text-sm">{errors.email.message}</div>
+      )}
+      <Input type="password" placeholder="Mật khẩu" {...register('password')} />
+      {errors.password && (
+        <div className="text-red-500 text-sm">{errors.password.message}</div>
+      )}
+      <Input
+        type="password"
+        placeholder="Nhập lại mật khẩu"
+        {...register('confirmPassword')}
+      />
+      {errors.confirmPassword && (
+        <div className="text-red-500 text-sm">{errors.confirmPassword.message}</div>
+      )}
+      <Input placeholder="Số điện thoại" {...register('phone')} />
+      {error && <div className="text-red-500 text-sm">{error}</div>}
+      <Button type="submit" className="w-full" disabled={isSubmitting}>
+        Đăng ký
+      </Button>
+      <div className="text-center text-sm">
+        <Link href="/login" className="text-sky-600 hover:underline">
+          Đã có tài khoản? Đăng nhập
+        </Link>
+      </div>
+    </form>
+  )
+}

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,6 +1,31 @@
 import { useAuthStore } from '@/store/auth'
+import { apiFetch } from '@/lib/api'
+import type { LoginInput, RegisterInput } from '@/lib/validators/auth'
 
 export function useAuth() {
-  const { user, token, isAuthenticated, login, logout } = useAuthStore()
-  return { user, token, isAuthenticated, login, logout }
+  const { user, token, isAuthenticated, login: setLogin, logout: clear } = useAuthStore()
+
+  const login = async (data: LoginInput) => {
+    const res = await apiFetch<{ user: typeof user; token: string }>('/api/auth/login', {
+      method: 'POST',
+      body: JSON.stringify(data),
+      auth: false,
+    })
+    setLogin(res.user, res.token)
+  }
+
+  const register = async (data: RegisterInput) => {
+    const res = await apiFetch<{ user: typeof user; token: string }>('/api/auth/register', {
+      method: 'POST',
+      body: JSON.stringify(data),
+      auth: false,
+    })
+    setLogin(res.user, res.token)
+  }
+
+  const logout = () => {
+    clear()
+  }
+
+  return { user, token, isAuthenticated, login, register, logout }
 }


### PR DESCRIPTION
## Summary
- implement LoginForm and RegisterForm using React Hook Form
- add customer login and register pages
- wire admin login page to new form
- add client-side auth guard for admin routes
- extend `useAuth` hook with API calls
- install react-hook-form dependencies

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68409345c4e88321af32318e4f4bfe56