### PR TITLE
Implement User module UI

### DIFF
--- a/src/app/(admin)/admin/users/[userId]/page.tsx
+++ b/src/app/(admin)/admin/users/[userId]/page.tsx
@@ -1,0 +1,9 @@
+import UserDetailView from '@/components/features/admin/users/UserDetailView'
+
+export default function AdminUserDetailPage() {
+  return (
+    <div className="p-4">
+      <UserDetailView />
+    </div>
+  )
+}

--- a/src/app/(admin)/admin/users/page.tsx
+++ b/src/app/(admin)/admin/users/page.tsx
@@ -1,0 +1,9 @@
+import UserTable from '@/components/features/admin/users/UserTable'
+
+export default function AdminUsersPage() {
+  return (
+    <div className="p-4">
+      <UserTable />
+    </div>
+  )
+}

--- a/src/app/(customer)/account/addresses/page.tsx
+++ b/src/app/(customer)/account/addresses/page.tsx
@@ -1,0 +1,5 @@
+import AddressList from '@/components/features/account/AddressList'
+
+export default function AddressesPage() {
+  return <AddressList />
+}

--- a/src/app/(customer)/account/layout.tsx
+++ b/src/app/(customer)/account/layout.tsx
@@ -1,0 +1,5 @@
+import AccountLayout from '@/components/features/account/AccountLayout'
+
+export default function AccountLayoutPage({ children }: { children: React.ReactNode }) {
+  return <AccountLayout>{children}</AccountLayout>
+}

--- a/src/app/(customer)/account/orders/page.tsx
+++ b/src/app/(customer)/account/orders/page.tsx
@@ -1,0 +1,3 @@
+export default function OrdersPage() {
+  return <div>Lịch sử đơn hàng</div>
+}

--- a/src/app/(customer)/account/profile/page.tsx
+++ b/src/app/(customer)/account/profile/page.tsx
@@ -1,0 +1,5 @@
+import ProfileForm from '@/components/features/account/ProfileForm'
+
+export default function ProfilePage() {
+  return <ProfileForm />
+}

--- a/src/components/features/account/AccountLayout.tsx
+++ b/src/components/features/account/AccountLayout.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { ReactNode } from 'react'
+import { Button } from '@/components/ui/Button'
+import { useAuth } from '@/hooks/useAuth'
+
+interface AccountLayoutProps {
+  children: ReactNode
+}
+
+export default function AccountLayout({ children }: AccountLayoutProps) {
+  const pathname = usePathname()
+  const { logout } = useAuth()
+
+  const links = [
+    { href: '/account/profile', label: 'Thông tin cá nhân' },
+    { href: '/account/addresses', label: 'Địa chỉ' },
+    { href: '/account/orders', label: 'Đơn hàng' },
+  ]
+
+  return (
+    <div className="flex gap-6 py-6">
+      <aside className="w-64 space-y-2">
+        {links.map((l) => (
+          <Link
+            key={l.href}
+            href={l.href}
+            className={
+              pathname === l.href
+                ? 'block p-2 rounded-md bg-sky-600 text-white'
+                : 'block p-2 rounded-md hover:bg-gray-100'
+            }
+          >
+            {l.label}
+          </Link>
+        ))}
+        <Button
+          type="button"
+          variant="secondary"
+          className="w-full"
+          onClick={logout}
+        >
+          Đăng xuất
+        </Button>
+      </aside>
+      <main className="flex-1">{children}</main>
+    </div>
+  )
+}

--- a/src/components/features/account/AddressForm.tsx
+++ b/src/components/features/account/AddressForm.tsx
@@ -1,0 +1,69 @@
+'use client'
+
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import * as z from 'zod'
+import { Button } from '@/components/ui/Button'
+import { Input } from '@/components/ui/Input'
+import { apiFetch } from '@/lib/api'
+
+const schema = z.object({
+  name: z.string().min(1),
+  phone: z.string().min(1),
+  line: z.string().min(1),
+  city: z.string().min(1),
+})
+
+export type AddressInput = z.infer<typeof schema>
+
+interface AddressFormProps {
+  initialData?: AddressInput & { id: string }
+  onSubmitSuccess: () => void
+  onCancel: () => void
+}
+
+export default function AddressForm({ initialData, onSubmitSuccess, onCancel }: AddressFormProps) {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+    reset,
+  } = useForm<AddressInput>({ resolver: zodResolver(schema), defaultValues: initialData })
+
+  const onSubmit = async (values: AddressInput) => {
+    if (initialData?.id) {
+      await apiFetch(`/api/users/me/addresses/${initialData.id}`, {
+        method: 'PUT',
+        body: JSON.stringify(values),
+      })
+    } else {
+      await apiFetch('/api/users/me/addresses', {
+        method: 'POST',
+        body: JSON.stringify(values),
+      })
+    }
+    onSubmitSuccess()
+    reset()
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-3 w-80">
+      <Input placeholder="Tên người nhận" {...register('name')} />
+      {errors.name && <div className="text-red-500 text-sm">{errors.name.message}</div>}
+      <Input placeholder="Số điện thoại" {...register('phone')} />
+      {errors.phone && <div className="text-red-500 text-sm">{errors.phone.message}</div>}
+      <Input placeholder="Đường" {...register('line')} />
+      {errors.line && <div className="text-red-500 text-sm">{errors.line.message}</div>}
+      <Input placeholder="Thành phố" {...register('city')} />
+      {errors.city && <div className="text-red-500 text-sm">{errors.city.message}</div>}
+      <div className="flex gap-2 justify-end mt-2">
+        <Button type="button" variant="secondary" onClick={onCancel}>
+          Hủy
+        </Button>
+        <Button type="submit" disabled={isSubmitting}>
+          Lưu
+        </Button>
+      </div>
+    </form>
+  )
+}

--- a/src/components/features/account/AddressList.tsx
+++ b/src/components/features/account/AddressList.tsx
@@ -1,0 +1,85 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Button } from '@/components/ui/Button'
+import { apiFetch } from '@/lib/api'
+import AddressForm from './AddressForm'
+
+interface Address {
+  id: string
+  name: string
+  phone: string
+  line: string
+  city: string
+  isDefault: boolean
+}
+
+export default function AddressList() {
+  const [addresses, setAddresses] = useState<Address[]>([])
+  const [editing, setEditing] = useState<Address | null>(null)
+
+  useEffect(() => {
+    apiFetch<Address[]>('/api/users/me/addresses').then(setAddresses)
+  }, [])
+
+  const remove = async (id: string) => {
+    await apiFetch(`/api/users/me/addresses/${id}`, { method: 'DELETE' })
+    setAddresses((prev) => prev.filter((a) => a.id !== id))
+  }
+
+  const setDefault = async (id: string) => {
+    await apiFetch(`/api/users/me/addresses/${id}/default`, { method: 'POST' })
+    setAddresses((prev) =>
+      prev.map((a) => ({ ...a, isDefault: a.id === id }))
+    )
+  }
+
+  const closeForm = () => setEditing(null)
+  const handleSaved = () => {
+    apiFetch<Address[]>('/api/users/me/addresses').then(setAddresses)
+    closeForm()
+  }
+
+  return (
+    <div>
+      <div className="space-y-4">
+        {addresses.map((a) => (
+          <div key={a.id} className="p-4 border rounded-md">
+            <div>{a.name}</div>
+            <div>{a.phone}</div>
+            <div>{a.line}</div>
+            <div>{a.city}</div>
+            <div className="flex gap-2 mt-2">
+              <Button size="sm" variant="secondary" onClick={() => setEditing(a)}>
+                Sửa
+              </Button>
+              <Button size="sm" variant="danger" onClick={() => remove(a.id)}>
+                Xóa
+              </Button>
+              {!a.isDefault && (
+                <Button size="sm" onClick={() => setDefault(a.id)}>
+                  Đặt mặc định
+                </Button>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+      <Button className="mt-4" onClick={() => setEditing({
+        id: '', name: '', phone: '', line: '', city: '', isDefault: false })}>
+        Thêm địa chỉ mới
+      </Button>
+      {editing && (
+        <div className="fixed inset-0 bg-black/40 flex items-center justify-center">
+          <div className="bg-white p-4 rounded-md">
+            <AddressForm
+              initialData={editing.id ? editing : undefined}
+              onSubmitSuccess={handleSaved}
+              onCancel={closeForm}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/features/account/ProfileForm.tsx
+++ b/src/components/features/account/ProfileForm.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { Button } from '@/components/ui/Button'
+import { Input } from '@/components/ui/Input'
+import { useAuth } from '@/hooks/useAuth'
+import { apiFetch } from '@/lib/api'
+import * as z from 'zod'
+
+const profileSchema = z.object({
+  name: z.string().min(1, 'Vui lòng nhập tên'),
+  phone: z.string().min(1, 'Vui lòng nhập số điện thoại'),
+})
+
+export type ProfileInput = z.infer<typeof profileSchema>
+
+export default function ProfileForm() {
+  const { user } = useAuth()
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<ProfileInput>({ resolver: zodResolver(profileSchema) })
+
+  useEffect(() => {
+    async function fetchData() {
+      const data = await apiFetch<{ name: string; phone: string }>('/api/users/me')
+      reset(data)
+    }
+    fetchData().catch(() => null)
+  }, [reset])
+
+  const onSubmit = async (values: ProfileInput) => {
+    await apiFetch('/api/users/me', {
+      method: 'PUT',
+      body: JSON.stringify(values),
+    })
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4 max-w-md">
+      <Input placeholder="Họ tên" {...register('name')} />
+      {errors.name && <div className="text-red-500 text-sm">{errors.name.message}</div>}
+      <Input value={user?.email || ''} readOnly className="opacity-50" />
+      <Input placeholder="Số điện thoại" {...register('phone')} />
+      {errors.phone && <div className="text-red-500 text-sm">{errors.phone.message}</div>}
+      <Button type="submit" disabled={isSubmitting}>Lưu thay đổi</Button>
+    </form>
+  )
+}

--- a/src/components/features/admin/users/UserDetailView.tsx
+++ b/src/components/features/admin/users/UserDetailView.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useParams } from 'next/navigation'
+import { apiFetch } from '@/lib/api'
+
+interface UserDetail {
+  id: string
+  name: string
+  email: string
+  phone?: string
+  role: string
+  addresses?: { id: string; line: string }[]
+}
+
+export default function UserDetailView() {
+  const params = useParams<{ userId: string }>()
+  const [user, setUser] = useState<UserDetail | null>(null)
+
+  useEffect(() => {
+    if (!params?.userId) return
+    apiFetch<UserDetail>(`/api/admin/users/${params.userId}`).then(setUser)
+  }, [params?.userId])
+
+  if (!user) return <div>Loading...</div>
+
+  return (
+    <div className="space-y-2">
+      <div>ID: {user.id}</div>
+      <div>Tên: {user.name}</div>
+      <div>Email: {user.email}</div>
+      {user.phone && <div>SĐT: {user.phone}</div>}
+      <div>Vai trò: {user.role}</div>
+      {user.addresses && (
+        <div>
+          <div className="font-medium mt-2">Địa chỉ:</div>
+          <ul className="list-disc pl-6">
+            {user.addresses.map((a) => (
+              <li key={a.id}>{a.line}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/features/admin/users/UserTable.tsx
+++ b/src/components/features/admin/users/UserTable.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { apiFetch } from '@/lib/api'
+
+interface UserRow {
+  id: string
+  name: string
+  email: string
+  role: string
+  createdAt: string
+}
+
+export default function UserTable() {
+  const [data, setData] = useState<UserRow[]>([])
+
+  useEffect(() => {
+    apiFetch<UserRow[]>('/api/admin/users').then(setData)
+  }, [])
+
+  return (
+    <table className="min-w-full border text-sm">
+      <thead>
+        <tr className="bg-gray-100 text-left">
+          <th className="p-2">ID</th>
+          <th className="p-2">Tên</th>
+          <th className="p-2">Email</th>
+          <th className="p-2">Vai trò</th>
+          <th className="p-2">Ngày tạo</th>
+        </tr>
+      </thead>
+      <tbody>
+        {data.map((u) => (
+          <tr key={u.id} className="border-t">
+            <td className="p-2">
+              <Link href={`/admin/users/${u.id}`} className="text-sky-600 hover:underline">
+                {u.id}
+              </Link>
+            </td>
+            <td className="p-2">{u.name}</td>
+            <td className="p-2">{u.email}</td>
+            <td className="p-2">{u.role}</td>
+            <td className="p-2">{new Date(u.createdAt).toLocaleDateString()}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,4 +1,4 @@
-import { useAuthStore } from '@/store/auth'
+import { useAuthStore, type User } from '@/store/auth'
 import { apiFetch } from '@/lib/api'
 import type { LoginInput, RegisterInput } from '@/lib/validators/auth'
 
@@ -6,7 +6,7 @@ export function useAuth() {
   const { user, token, isAuthenticated, login: setLogin, logout: clear } = useAuthStore()
 
   const login = async (data: LoginInput) => {
-    const res = await apiFetch<{ user: typeof user; token: string }>('/api/auth/login', {
+    const res = await apiFetch<{ user: User; token: string }>('/api/auth/login', {
       method: 'POST',
       body: JSON.stringify(data),
       auth: false,
@@ -15,7 +15,7 @@ export function useAuth() {
   }
 
   const register = async (data: RegisterInput) => {
-    const res = await apiFetch<{ user: typeof user; token: string }>('/api/auth/register', {
+    const res = await apiFetch<{ user: User; token: string }>('/api/auth/register', {
       method: 'POST',
       body: JSON.stringify(data),
       auth: false,

--- a/src/store/auth.ts
+++ b/src/store/auth.ts
@@ -4,6 +4,7 @@ import { persist } from 'zustand/middleware'
 export interface User {
   id: string
   name: string
+  email: string
   role: string
 }
 


### PR DESCRIPTION
## Summary
- fix type error in `useAuth` by ensuring user data isn't nullable
- store email on user objects
- add account page components (AccountLayout, ProfileForm, AddressList, AddressForm)
- add admin user components (UserTable, UserDetailView)
- create account and admin user pages

## Testing
- `npm run lint`
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6840966d7ce48321a3d0e4d29934fd3b