### PR TITLE
Implement category frontend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "react-dom": "^19.0.0",
         "react-hook-form": "^7.57.0",
         "slugify": "^1.6.6",
+        "swr": "^2.3.3",
         "tailwind-merge": "^3.3.0",
         "zod": "^3.22.4",
         "zustand": "^5.0.5"
@@ -1448,7 +1449,7 @@
       "version": "19.1.6",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.6.tgz",
       "integrity": "sha512-JeG0rEWak0N6Itr6QUx+X60uQmN+5t3j9r/OVDtWzFXKaj6kD1BwJzOksD0FF6iWxZlbE1kB0q9vtnU2ekqa1Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -2525,7 +2526,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -2648,6 +2649,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/detect-libc": {
@@ -6046,6 +6056,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swr": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.3.tgz",
+      "integrity": "sha512-dshNvs3ExOqtZ6kJBaAsabhPdHyeY4P2cKwRCniDVifBMoG/SVI7tfLWqPXriVspf2Rg4tPzXJTnwaihIeFw2A==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/tailwind-merge": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.3.0.tgz",
@@ -6325,6 +6348,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.57.0",
     "slugify": "^1.6.6",
+    "swr": "^2.3.3",
     "tailwind-merge": "^3.3.0",
     "zod": "^3.22.4",
     "zustand": "^5.0.5"

--- a/src/app/(admin)/admin/categories/page.tsx
+++ b/src/app/(admin)/admin/categories/page.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import { useState } from 'react'
+import { Button } from '@/components/ui/Button'
+import CategoryTable from '@/components/features/admin/categories/CategoryTable'
+import CategoryForm from '@/components/features/admin/categories/CategoryForm'
+import type { CategoryNode } from '@/hooks/useCategories'
+
+export default function AdminCategoriesPage() {
+  const [editing, setEditing] = useState<CategoryNode | null>(null)
+  const [showForm, setShowForm] = useState(false)
+  const [refreshKey, setRefreshKey] = useState(0)
+
+  const handleSuccess = () => {
+    setRefreshKey((k) => k + 1)
+    setShowForm(false)
+    setEditing(null)
+  }
+
+  return (
+    <div className="p-4">
+      <div className="mb-4 text-right">
+        <Button onClick={() => { setEditing(null); setShowForm(true) }}>Thêm mới</Button>
+      </div>
+      <CategoryTable
+        onEdit={(cat) => { setEditing(cat); setShowForm(true) }}
+        refreshKey={refreshKey}
+      />
+      {showForm && (
+        <div className="fixed inset-0 bg-black/40 flex items-center justify-center">
+          <div className="bg-white p-4 rounded-md">
+            <CategoryForm
+              initialData={editing ?? undefined}
+              onSubmitSuccess={handleSuccess}
+            />
+            <div className="flex justify-end mt-2">
+              <Button variant="secondary" onClick={() => { setShowForm(false); setEditing(null) }}>
+                Đóng
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/features/admin/categories/CategoryForm.tsx
+++ b/src/components/features/admin/categories/CategoryForm.tsx
@@ -1,0 +1,79 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { Button } from '@/components/ui/Button'
+import { Input } from '@/components/ui/Input'
+import { apiFetch } from '@/lib/api'
+import {
+  createCategorySchema,
+  type CreateCategoryInput,
+} from '@/lib/validators/category'
+import type { CategoryNode } from '@/hooks/useCategories'
+
+interface CategoryFormProps {
+  initialData?: CreateCategoryInput & { id: string }
+  onSubmitSuccess: () => void
+}
+
+export default function CategoryForm({ initialData, onSubmitSuccess }: CategoryFormProps) {
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isSubmitting },
+  } = useForm<CreateCategoryInput>({
+    resolver: zodResolver(createCategorySchema),
+    defaultValues: initialData,
+  })
+  const [parents, setParents] = useState<CategoryNode[]>([])
+
+  useEffect(() => {
+    apiFetch<{ categories: CategoryNode[] }>('/api/categories?tree=true').then((res) =>
+      setParents(res.categories)
+    )
+  }, [])
+
+  const onSubmit = async (values: CreateCategoryInput) => {
+    if (initialData?.id) {
+      await apiFetch(`/api/admin/categories/${initialData.id}`, {
+        method: 'PUT',
+        body: JSON.stringify(values),
+      })
+    } else {
+      await apiFetch('/api/admin/categories', {
+        method: 'POST',
+        body: JSON.stringify(values),
+      })
+    }
+    onSubmitSuccess()
+    reset()
+  }
+
+  const renderOptions = (cats: CategoryNode[], level = 0) =>
+    cats.map((c) => (
+      <>
+        <option key={c.id} value={c.id}>
+          {`${'--'.repeat(level)} ${c.name}`}
+        </option>
+        {c.children && renderOptions(c.children, level + 1)}
+      </>
+    ))
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-3 w-80">
+      <Input placeholder="Tên danh mục" {...register('name')} />
+      {errors.name && <div className="text-red-500 text-sm">{errors.name.message}</div>}
+      <Input placeholder="Mô tả" {...register('description')} />
+      <select {...register('parentId')} className="border p-2 rounded-md w-full text-sm">
+        <option value="">Chọn danh mục cha</option>
+        {renderOptions(parents)}
+      </select>
+      <Input placeholder="URL hình ảnh" {...register('imageUrl')} />
+      <div className="flex justify-end">
+        <Button type="submit" disabled={isSubmitting}>{initialData ? 'Cập nhật' : 'Tạo mới'}</Button>
+      </div>
+    </form>
+  )
+}

--- a/src/components/features/admin/categories/CategoryTable.tsx
+++ b/src/components/features/admin/categories/CategoryTable.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import { useEffect, useState, Fragment } from 'react'
+import { Button } from '@/components/ui/Button'
+import { apiFetch } from '@/lib/api'
+import type { CategoryNode } from '@/hooks/useCategories'
+
+interface CategoryTableProps {
+  onEdit: (category: CategoryNode) => void
+  refreshKey: number
+}
+
+export default function CategoryTable({ onEdit, refreshKey }: CategoryTableProps) {
+  const [data, setData] = useState<CategoryNode[]>([])
+
+  useEffect(() => {
+    apiFetch<{ categories: CategoryNode[] }>(
+      '/api/categories?tree=true'
+    ).then((res) => setData(res.categories))
+  }, [refreshKey])
+
+  const remove = async (id: string) => {
+    if (!confirm('Xóa danh mục?')) return
+    await apiFetch(`/api/admin/categories/${id}`, { method: 'DELETE' })
+    setData((prev) => prev.filter((c) => c.id !== id))
+  }
+
+  const renderRows = (cats: CategoryNode[], level = 0) =>
+    cats.map((c) => (
+      <Fragment key={c.id}>
+        <tr className="border-t">
+          <td className="p-2" style={{ paddingLeft: level * 16 }}>{c.name}</td>
+          <td className="p-2">{c.slug}</td>
+          <td className="p-2">{c.description || ''}</td>
+          <td className="p-2">{c._count?.products ?? 0}</td>
+          <td className="p-2 space-x-2">
+            <Button size="sm" variant="secondary" onClick={() => onEdit(c)}>
+              Sửa
+            </Button>
+            <Button size="sm" variant="danger" onClick={() => remove(c.id)}>
+              Xóa
+            </Button>
+          </td>
+        </tr>
+        {c.children && renderRows(c.children, level + 1)}
+      </Fragment>
+    ))
+
+  return (
+    <table className="min-w-full border text-sm">
+      <thead>
+        <tr className="bg-gray-100 text-left">
+          <th className="p-2">Tên</th>
+          <th className="p-2">Slug</th>
+          <th className="p-2">Mô tả</th>
+          <th className="p-2">Sản phẩm</th>
+          <th className="p-2"></th>
+        </tr>
+      </thead>
+      <tbody>{renderRows(data)}</tbody>
+    </table>
+  )
+}

--- a/src/components/features/categories/CategoryBreadcrumb.tsx
+++ b/src/components/features/categories/CategoryBreadcrumb.tsx
@@ -1,0 +1,47 @@
+'use client'
+
+import Link from 'next/link'
+import { useEffect, useState } from 'react'
+import { apiFetch } from '@/lib/api'
+import { useCategory, type CategoryNode } from '@/hooks/useCategories'
+
+interface CategoryBreadcrumbProps {
+  slugOrId: string
+}
+
+export default function CategoryBreadcrumb({ slugOrId }: CategoryBreadcrumbProps) {
+  const { data: category } = useCategory(slugOrId)
+  const [parents, setParents] = useState<CategoryNode[]>([])
+
+  useEffect(() => {
+    async function fetchParents(parentId?: string) {
+      const arr: CategoryNode[] = []
+      let pid = parentId
+      while (pid) {
+        const res = await apiFetch<{ category: CategoryNode }>(`/api/categories/${pid}`)
+        arr.unshift(res.category)
+        pid = res.category.parentId
+      }
+      setParents(arr)
+    }
+    if (category) {
+      fetchParents(category.parentId).catch(() => null)
+    }
+  }, [category])
+
+  if (!category) return null
+
+  const chain = [...parents, category]
+
+  return (
+    <nav className="text-sm">
+      <Link href="/">Trang chủ</Link>
+      {chain.map((c) => (
+        <span key={c.id}>
+          {' > '}
+          <Link href={`/products?category=${c.slug}`}>{c.name}</Link>
+        </span>
+      ))}
+    </nav>
+  )
+}

--- a/src/components/features/categories/CategoryNavigation.tsx
+++ b/src/components/features/categories/CategoryNavigation.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import Link from 'next/link'
+import { useCategoryTree, type CategoryNode } from '@/hooks/useCategories'
+
+function renderMenu(categories: CategoryNode[]): JSX.Element {
+  return (
+    <ul className="pl-4 space-y-1">
+      {categories.map((c) => (
+        <li key={c.id}>
+          <Link href={`/products?category=${c.slug}`}>{c.name}</Link>
+          {c.children && c.children.length > 0 && renderMenu(c.children)}
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+export default function CategoryNavigation() {
+  const { data } = useCategoryTree()
+
+  if (!data) return <div>Loading...</div>
+
+  return <nav>{renderMenu(data)}</nav>
+}

--- a/src/hooks/useCategories.ts
+++ b/src/hooks/useCategories.ts
@@ -1,0 +1,32 @@
+import useSWR from 'swr'
+import { apiFetch } from '@/lib/api'
+
+export interface CategoryNode {
+  id: string
+  name: string
+  slug: string
+  description?: string
+  imageUrl?: string
+  parentId?: string
+  children?: CategoryNode[]
+  _count?: { products: number }
+}
+
+const fetcher = (url: string) =>
+  apiFetch<{ categories: CategoryNode[] }>(url).then((res) => res.categories)
+
+export function useCategoryTree() {
+  return useSWR('/api/categories?tree=true', fetcher)
+}
+
+export function useCategories(parentId?: string) {
+  const url = parentId ? `/api/categories?parentId=${parentId}` : '/api/categories'
+  return useSWR(url, fetcher)
+}
+
+export function useCategory(slugOrId: string | null) {
+  return useSWR(
+    slugOrId ? `/api/categories/${slugOrId}` : null,
+    (url) => apiFetch<{ category: CategoryNode }>(url).then((res) => res.category)
+  )
+}


### PR DESCRIPTION
## Summary
- add SWR hook for categories
- implement customer components `CategoryNavigation` and `CategoryBreadcrumb`
- add admin components `CategoryTable` and `CategoryForm`
- create admin category management page
- install `swr`

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch Google fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6840984f03288321a75541d4e4ec7fbc